### PR TITLE
Merge 'docker-prep' into 'master' 

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,10 +54,10 @@ app.render_template = render_template
 
 @app.listener("before_server_start")
 async def init(app, loop):
-    if config.MONGO_USER and config.MONGO_PASS:
-        mongo_uri = f"mongodb://{quote_plus(config.MONGO_USER)}:{quote_plus(config.MONGO_PASS)}@{config.MONGO_HOST}"
+    if config.mongoUser and config.mongoPass:
+        mongo_uri = f"mongodb://{quote_plus(config.mongoUser)}:{quote_plus(config.mongoPass)}@{config.mongoHost}"
     else:
-        mongo_uri = f"mongodb://{config.MONGO_HOST}"
+        mongo_uri = f"mongodb://{config.mongoHost}"
     
     app.db = AsyncIOMotorClient(mongo_uri).modmail
     app.session = aiohttp.ClientSession(loop=loop)

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 from functools import wraps
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode, urlparse, quote_plus
 
 from motor.motor_asyncio import AsyncIOMotorClient
 from sanic import Sanic, response
@@ -54,7 +54,13 @@ app.render_template = render_template
 
 @app.listener("before_server_start")
 async def init(app, loop):
-    app.db = AsyncIOMotorClient(config.MONGO_URI).modmail
+    if config.MONGO_USER and config.MONGO_PASS:
+        mongo_uri = f"mongodb://{quote_plus(config.MONGO_USER)}:{quote_plus(config.MONGO_PASS)}@{config.MONGO_HOST}"
+    else:
+        mongo_uri = f"mongodb://{config.MONGO_HOST}"
+    
+    print(mongo_uri)
+    app.db = AsyncIOMotorClient(mongo_uri).modmail
     app.session = aiohttp.ClientSession(loop=loop)
     if app.using_oauth:
         app.guild_id = config.GUILD_ID

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ if prefix == "NONE":
     prefix = ""
 
 app = Sanic(__name__)
-app.using_oauth = OAUTH2_CLIENT_ID and OAUTH2_CLIENT_SECRET
+app.using_oauth = len(config.OAUTH2_WHITELIST) != 0
 app.bot_id = OAUTH2_CLIENT_ID
 
 Session(app, interface=InMemorySessionInterface())
@@ -94,6 +94,8 @@ async def get_user_info(token):
 
 
 async def get_user_roles(user_id):
+    if not app.guild_id and app.bot_token: return []
+
     url = ROLE_URL.format(guild_id=app.guild_id, user_id=user_id)
     headers = {"Authorization": f"Bot {app.bot_token}"}
     async with app.session.get(url, headers=headers) as resp:

--- a/app.py
+++ b/app.py
@@ -195,6 +195,7 @@ async def get_logs_file(request, document):
 
 if __name__ == "__main__":
     app.run(
+        # You can change these using environment variables
         host=os.getenv("HOST", "127.0.0.1"),
         port=os.getenv("PORT", 8880),
         debug=bool(os.getenv("DEBUG", False)),

--- a/app.py
+++ b/app.py
@@ -59,7 +59,6 @@ async def init(app, loop):
     else:
         mongo_uri = f"mongodb://{config.MONGO_HOST}"
     
-    print(mongo_uri)
     app.db = AsyncIOMotorClient(mongo_uri).modmail
     app.session = aiohttp.ClientSession(loop=loop)
     if app.using_oauth:

--- a/config.example.py
+++ b/config.example.py
@@ -4,7 +4,9 @@ OAUTH2_CLIENT_ID = 'int as str'
 OAUTH2_CLIENT_SECRET = ''
 OAUTH2_REDIRECT_URI = 'http://example.com/callback'
 
-MONGO_URI = 'mongodb://user:pass@127.0.0.1/?authSource=admin'
+MONGO_USER = ''
+MONGO_PASS = ''
+MONGO_HOST = '127.0.0.1'
 
 GUILD_ID = 'int as str'
 BOT_TOKEN = ''

--- a/config.example.py
+++ b/config.example.py
@@ -1,8 +1,8 @@
 # type: ignore
 
-MONGO_USER = ''
-MONGO_PASS = ''
-MONGO_HOST = '127.0.0.1'
+mongoUser = ''
+mongoPass = ''
+mongoHost = ''
 
 # Can contain User IDs and Role IDs. Leave empty to disable OAuth.
 OAUTH2_WHITELIST = [] 

--- a/config.example.py
+++ b/config.example.py
@@ -1,12 +1,17 @@
 # type: ignore
 
-OAUTH2_CLIENT_ID = 'int as str'
-OAUTH2_CLIENT_SECRET = ''
-OAUTH2_REDIRECT_URI = 'http://example.com/callback'
-
 MONGO_USER = ''
 MONGO_PASS = ''
 MONGO_HOST = '127.0.0.1'
 
-GUILD_ID = 'int as str'
+# Can contain User IDs and Role IDs. Leave empty to disable OAuth.
+OAUTH2_WHITELIST = [] 
+
+# Only required if you use OAuth
+OAUTH2_CLIENT_ID = ''
+OAUTH2_CLIENT_SECRET = ''
+OAUTH2_REDIRECT_URI = 'http://example.com/callback'
+
+# Only required if you use Role IDs in your OAuth Whitelist
+GUILD_ID = ''
 BOT_TOKEN = ''


### PR DESCRIPTION
Part of a series of development-related changes and fixes across codebases for the MechaDocker project. I recommend against using the squash & merge option in case individual changes need to be reverted later.

# Changes
***Important config changes***
- Updates the config to use mongoUser, mongoPass, and mongoHost (like MechaBowser and Parakarry), changed from a connection uri.
- The OAuth whitelist is now pulled from the config file instead of the config table.
   -  The 'everyone' option was removed in favor of a blank whitelist disabling oauth.
---
- The config file is now ignored by pylance.
- The config file was restructured, but there are no other breaking changes then those above.